### PR TITLE
fix(index): remove catch statement to allow rejection, always return promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,16 @@ $ yarn add ssl-checker
 ## Usage
 
 ```javascript
-var sslChecker = require("ssl-checker")
+const sslChecker =  require("ssl-checker");
 
-sslChecker('dyaa.me').then(result => console.info(result));
+sslChecker("github.com").then(console.log).catch(console.error);
+sslChecker("github").then(console.log).catch((err) => {
+  if (err.code === 'ENOTFOUND') {
+    console.log("Please get back only or fix hostname");
+  } else {
+    console.error(err);
+  }
+});
 ```
 
 ## Options

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ module.exports = (host, method, port) => {
 		host: host,
 		method: method || 'HEAD',
 		port: port || 443,
-		rejectUnauthorized: false
+		rejectUnauthorized: false,
+		agent: false,
 	};
 
 	let numericPort = (!isNaN(parseFloat(options.port)) && isFinite(options.port));

--- a/index.js
+++ b/index.js
@@ -16,8 +16,7 @@ module.exports = (host, method, port) => {
 		host: host,
 		method: method || 'HEAD',
 		port: port || 443,
-		rejectUnauthorized: false,
-		agent: false,
+		rejectUnauthorized: false
 	};
 
 	let numericPort = (!isNaN(parseFloat(options.port)) && isFinite(options.port));
@@ -25,8 +24,8 @@ module.exports = (host, method, port) => {
 	let daysBetween = (from, to) => Math.round(Math.abs((+from) - (+to))/8.64e7);
 
 	if (options.host === null || options.port === null) throw new Error("Invalid host or port");
-	try {
-		return new Promise(function(resolve, reject) {
+	return new Promise(function(resolve, reject) {
+		try {
 			const req = https.request(options, res => {
 				let { valid_from, valid_to } = res.connection.getPeerCertificate();
 				resolve({
@@ -37,9 +36,8 @@ module.exports = (host, method, port) => {
 			});
 			req.on('error', (e) => { reject(e) });
 			req.end();
-		}).catch(console.error);
-
-	} catch (e) {
-		throw new Error(e)
-	}
+		} catch (e) {
+			reject(e);
+		}
+	})
 };

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@ var checker = require('../index');
 
 describe('SSL Checker', () => {
 	it('should return correct properties', () => {
-		return checker('dyaa.me').then(data => {
+		return checker('github.com').then(data => {
 			return expect(data).to.have.property('valid_from');
 		}).catch(console.error);
 	});


### PR DESCRIPTION
Fixes https://github.com/dyaa/node-ssl-checker/issues/9