### PR TITLE
Show negative days remaining for expired certificates

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,11 +28,20 @@ module.exports = (host, method, port) => {
 	try {
 		return new Promise(function(resolve, reject) {
 			const req = https.request(options, res => {
+
 				let { valid_from, valid_to } = res.connection.getPeerCertificate();
+				let days_remaining = daysBetween(new Date(), new Date(valid_to))
+				
+				// Check if a certificate has already expired
+				let now = new Date();
+				if (new Date(valid_to).getTime() < now.getTime()){
+					days_remaining = -days_remaining;
+				}
+
 				resolve({
 					valid_from: valid_from,
 					valid_to: valid_to,
-					days_remaining: daysBetween(new Date(), new Date(valid_to))
+					days_remaining: days_remaining
 				});
 			});
 			req.on('error', (e) => { reject(e) });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssl-checker",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "ssl-checker",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -10,4 +10,10 @@ describe('SSL Checker', () => {
 			return expect(data).to.have.property('valid_from');
 		}).catch(console.error);
 	});
+
+	it('should return negative days remaining for expired certs ', () => {
+		return checker('expired.badssl.com').then(data => {
+			return expect(data.days_remaining).below(0);
+		}).catch(console.error);
+	});
 });


### PR DESCRIPTION
Currently it shows days remaining as a positive number, while the cert has long expired.

Fixes #8 